### PR TITLE
Add utility to try to rescue frames from a corrupted nd2 file

### DIFF
--- a/src/nd2/__init__.py
+++ b/src/nd2/__init__.py
@@ -4,9 +4,18 @@ except ImportError:
     __version__ = "unknown"
 __author__ = "Talley Lambert"
 __email__ = "talley.lambert@gmail.com"
-__all__ = ["ND2File", "imread", "structures", "AXIS", "is_supported_file"]
+__all__ = [
+    "ND2File",
+    "imread",
+    "structures",
+    "AXIS",
+    "is_supported_file",
+    "read_chunkmap",
+    "rescue_nd2",
+]
 
 
 from . import structures
+from ._chunkmap import read_chunkmap, rescue_nd2
 from ._util import AXIS, is_supported_file
 from .nd2file import ND2File, imread

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -1,0 +1,18 @@
+import nd2
+import numpy as np
+
+
+def test_rescue(single_nd2):
+    # TODO: we could potentially put more of this logic into convenience functions
+    # we can't do too much magic about guessing shape and dtype since some files
+    # may not have that information intact
+    with nd2.ND2File(single_nd2) as rdr:
+        real_read = rdr.asarray()
+        raw_frames = [
+            f.transpose((2, 0, 1, 3)).squeeze()
+            for f in nd2.rescue_nd2(
+                single_nd2, frame_shape=rdr._raw_frame_shape, dtype=rdr.dtype
+            )
+        ]
+        raw_read: np.ndarray = np.stack(raw_frames).reshape(rdr.shape)
+        np.testing.assert_array_equal(real_read, raw_read)


### PR DESCRIPTION
```python
from nd2 import rescue_nd2

for f in rescue_nd2('bad_file.nd2', frame_shape=(512, 512, 3), dtype='uint16'):
    ...  # do something with the rescued frame
```

note that frame_shape must be in the shape as it appears on disk, which is usually (Y, X, C)