### PR TITLE
fix numpy 1.22.4 bug

### DIFF
--- a/src/nd2/nd2file.py
+++ b/src/nd2/nd2file.py
@@ -365,8 +365,9 @@ class ND2File:
                             f"Cannot get chunk {block_id} for single frame image."
                         )
                     idx = 0
-                data = self._get_frame(cast(int, idx))[(np.newaxis,) * ncoords]
-                return data.copy() if copy else data
+                data = self._get_frame(cast(int, idx))
+                data = data.copy() if copy else data
+                return data[(np.newaxis,) * ncoords]
             finally:
                 if was_closed:
                     self.close()
@@ -470,7 +471,7 @@ class ND2File:
 
         coords: Dict[str, Sized] = {
             AXIS.Y: np.arange(self.attributes.heightPx) * dy,
-            AXIS.X: np.arange(self.attributes.widthPx) * dx,
+            AXIS.X: np.arange(self.attributes.widthPx or 1) * dx,
             AXIS.CHANNEL: self._channel_names,
             AXIS.POSITION: ["XYPos:0"],  # maybe overwritten below
         }


### PR DESCRIPTION
Numpy 1.22.4 (specifically, https://github.com/numpy/numpy/pull/21446) changed the way that arrays are created from buffers.  It is causing tests here to [fail](https://github.com/tlambert03/nd2/runs/6615589606?check_suite_focus=true) specifically in the case where a dask array is requested _without_ using the "ResourceBackedArray" protocol, the underlying file is closed, and then the array is computed.

To be sure, this was a risky operation to begin with :joy: ... so the numpy error is good.

This fixes the copy operation that should prevent it 