### PR TITLE
feat: add `read_using_sdk` parameter, default to True for compressed files

### DIFF
--- a/src/nd2/_sdk/latest.pyi
+++ b/src/nd2/_sdk/latest.pyi
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -12,6 +12,7 @@ class ND2Reader:
         path: Union[str, Path],
         validate_frames: bool = False,
         search_window: int = 100,
+        read_using_sdk: Optional[bool] = None,
     ) -> None: ...
     def open(self) -> None: ...
     def close(self) -> None: ...

--- a/src/nd2/_util.py
+++ b/src/nd2/_util.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime
-from typing import IO, TYPE_CHECKING, Any, Callable, NamedTuple, Union
+from typing import IO, TYPE_CHECKING, Any, Callable, NamedTuple, Optional, Union
 
 if TYPE_CHECKING:
     from os import PathLike
@@ -38,7 +38,10 @@ def is_supported_file(
 
 
 def get_reader(
-    path: str, validate_frames: bool = False, search_window: int = 100
+    path: str,
+    validate_frames: bool = False,
+    search_window: int = 100,
+    read_using_sdk: Optional[bool] = None,
 ) -> Union["ND2Reader", "LegacyND2Reader"]:
     with open(path, "rb") as fh:
         magic_num = fh.read(4)
@@ -46,7 +49,10 @@ def get_reader(
             from ._sdk.latest import ND2Reader
 
             return ND2Reader(
-                path, validate_frames=validate_frames, search_window=search_window
+                path,
+                validate_frames=validate_frames,
+                search_window=search_window,
+                read_using_sdk=read_using_sdk,
             )
         elif magic_num == OLD_HEADER_MAGIC:
             from ._legacy import LegacyND2Reader

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,17 @@ OLD: List[Path] = []
 for x in ALL:
     NEW.append(x) if is_new_format(str(x)) else OLD.append(x)
 
+SINGLE = DATA / "dims_t3c2y32x32.nd2"
+
 
 @pytest.fixture
 def single_nd2():
-    return DATA / "dims_t3c2y32x32.nd2"
+    return SINGLE
+
+
+@pytest.fixture(params=ALL[:20])
+def small_nd2s(request):
+    return request.param
 
 
 @pytest.fixture(params=ALL, ids=lambda x: x.name)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -266,3 +266,23 @@ def test_chunkmap(validate):
     assert isinstance(d, np.ndarray)
     assert d.shape == (512, 512)
     assert np.array_equal(d[250:255, 250:255], expected)
+
+
+def test_with_without_sdk(small_nd2s: Path):
+    with ND2File(small_nd2s, read_using_sdk=True) as withsdk:
+        ary1 = withsdk.asarray()
+        dsk1 = withsdk.to_dask()
+        np.testing.assert_array_equal(ary1, dsk1)
+
+    if not withsdk.attributes.compressionType:
+        with ND2File(small_nd2s, read_using_sdk=False) as nosdk:
+            ary2 = nosdk.asarray()
+            dsk2 = nosdk.to_dask()
+            np.testing.assert_array_equal(ary2, dsk2)
+            if not nosdk.attributes.compressionType:
+                np.testing.assert_array_equal(ary1, ary2)
+    else:
+        with pytest.raises(
+            ValueError, match="compressed nd2 files with `read_using_sdk=False`"
+        ):
+            imread(small_nd2s, read_using_sdk=False)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -273,8 +273,9 @@ def test_with_without_sdk(small_nd2s: Path):
         ary1 = withsdk.asarray()
         dsk1 = withsdk.to_dask()
         np.testing.assert_array_equal(ary1, dsk1)
+        compressed = bool(withsdk.attributes.compressionType)
 
-    if not withsdk.attributes.compressionType:
+    if not compressed:
         with ND2File(small_nd2s, read_using_sdk=False) as nosdk:
             ary2 = nosdk.asarray()
             dsk2 = nosdk.to_dask()

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -7,7 +7,7 @@ from nd2._sdk import latest
 
 
 def test_new_sdk(new_nd2: Path):
-    with latest.ND2Reader(new_nd2) as nd:
+    with latest.ND2Reader(new_nd2, read_using_sdk=True) as nd:
         a = nd._attributes()
         assert isinstance(a, dict)
         assert isinstance(nd._metadata(), dict)
@@ -22,9 +22,9 @@ def test_new_sdk(new_nd2: Path):
         # sometimes _seq_count is lower than attrs.sequenceCount
         # if it is, _seq_count provides the highest "good" frame you can retrieve.
         if scount != a.get("sequenceCount"):
-            nd._image(scount - 1)
+            nd._read_image(scount - 1)
             with pytest.raises(IndexError):
-                nd._image(scount)
+                nd._read_image(scount)
 
         midframe = scount // 2
         if midframe > 1:
@@ -34,7 +34,7 @@ def test_new_sdk(new_nd2: Path):
 
         assert isinstance(nd._seq_index_from_coords((0,) * csize), int)
         assert isinstance(nd._coord_info(), list)
-        frame = nd._image(midframe)
+        frame = nd._read_image(midframe)
         assert isinstance(frame, np.ndarray)
         assert frame.shape == (a["heightPx"], a["widthPx"], a["componentCount"])
 


### PR DESCRIPTION
fixes #72

This exposes the ability to use the sdk to read frames vs the current behavior of reading the chunkmap and using a numpy memmap.  This _may_ also help speed in reading metadata (#71)

The current default of `None` means: use the sdk reader if the file is compressed, otherwise use numpy memmap.
This default might change in the future