### PR TITLE
fix: close handles on object deletion

### DIFF
--- a/src/nd2/__init__.py
+++ b/src/nd2/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "BinaryLayers",
     "imread",
     "is_supported_file",
+    "is_legacy",
     "ND2File",
     "read_chunkmap",
     "rescue_nd2",
@@ -20,5 +21,5 @@ __all__ = [
 from . import structures
 from ._binary import BinaryLayer, BinaryLayers
 from ._chunkmap import read_chunkmap, rescue_nd2
-from ._util import AXIS, is_supported_file
+from ._util import AXIS, is_legacy, is_supported_file
 from .nd2file import ND2File, imread

--- a/src/nd2/_util.py
+++ b/src/nd2/_util.py
@@ -37,6 +37,23 @@ def is_supported_file(
         return fh.read(4) in (NEW_HEADER_MAGIC, OLD_HEADER_MAGIC)
 
 
+def is_legacy(path: "StrOrBytesPath") -> bool:
+    """Return `True` if `path` is a legacy ND2 file.
+
+    Parameters
+    ----------
+    path : Union[str, bytes, PathLike]
+        A path to query
+
+    Returns
+    -------
+    bool
+        Whether the file is a legacy ND2 file.
+    """
+    with open(path, "rb") as fh:
+        return fh.read(4) == OLD_HEADER_MAGIC
+
+
 def get_reader(
     path: str,
     validate_frames: bool = False,

--- a/src/nd2/nd2file.py
+++ b/src/nd2/nd2file.py
@@ -143,7 +143,13 @@ class ND2File:
 
     def __del__(self) -> None:
         """Delete file handle on garbage collection."""
-        self.close()
+        if not getattr(self, "_closed", True):
+            warnings.warn(
+                "ND2File file not closed before garbage collection. "
+                "Please use `with ND2File(...):` context or call `.close()`.",
+                stacklevel=2,
+            )
+            self._rdr.close()
 
     def __exit__(self, *_) -> None:
         self.close()

--- a/src/nd2/nd2file.py
+++ b/src/nd2/nd2file.py
@@ -141,6 +141,10 @@ class ND2File:
         self.open()
         return self
 
+    def __del__(self) -> None:
+        """Delete file handle on garbage collection."""
+        self.close()
+
     def __exit__(self, *_) -> None:
         self.close()
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -364,5 +364,7 @@ def test_gc_triggers_cleanup(single_nd2):
     import gc
 
     f: ND2File | None = ND2File(single_nd2)
-    f = None  # noqa: F841
-    gc.collect()
+
+    with pytest.warns(UserWarning, match="ND2File file not closed"):
+        f = None  # noqa: F841
+        gc.collect()

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -356,3 +356,13 @@ def test_recorded_data() -> None:
             -4155.462732842248,
             3916.7250000000004,
         ]
+
+
+def test_gc_triggers_cleanup(single_nd2):
+    # this test takes advantage of the `no_files_left_open``
+    # fixture in conftest to ensure that the file is closed
+    import gc
+
+    f: ND2File | None = ND2File(single_nd2)
+    f = None  # noqa: F841
+    gc.collect()


### PR DESCRIPTION
This closes an underlying file handle on object deletion (with a warning) in the case where the file is left open.

partial fix for #114 ... (though I haven't yet been able to check whether this solves the case of an exception on file open)