### PR TITLE
Make 'periodDiff' optional in TimeLoopParams construction

### DIFF
--- a/src/nd2/structures.py
+++ b/src/nd2/structures.py
@@ -85,6 +85,8 @@ class TimeLoop(_Loop):
 
     def __post_init__(self):
         if isinstance(self.parameters, dict):
+            if "periodDiff" not in self.parameters:
+                self.parameters["periodDiff"] = None
             self.parameters = TimeLoopParams(**self.parameters)
 
 


### PR DESCRIPTION
[See discussion here](https://github.com/AllenCellModeling/aicsimageio/issues/488).

This is intended to allow `periodDiff` be an optional parameter to `TimeLoopParams`