### PR TITLE
feat: add `python -m nd2.index` cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ exclude_lines = [
     "\\.\\.\\.",
     "except ImportError",
     "except NotImplementedError",
+    "if __name__ == .__main__.:",
 ]
 
 [tool.coverage.run]

--- a/src/nd2/_pysdk/_chunk_decode.py
+++ b/src/nd2/_pysdk/_chunk_decode.py
@@ -6,13 +6,13 @@ import struct
 from contextlib import contextmanager
 from io import BufferedReader
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator, cast
+from typing import TYPE_CHECKING, BinaryIO, Iterator, cast
 
 import numpy as np
 
 if TYPE_CHECKING:
     from os import PathLike
-    from typing import BinaryIO, Final
+    from typing import Final
 
     from numpy.typing import DTypeLike
 
@@ -66,7 +66,7 @@ SIG_CHUNKMAP_LOC = struct.Struct("32sQ")
 # uint64_t offset
 
 
-def get_version(fh: BufferedReader | StrOrBytesPath) -> tuple[int, int]:
+def get_version(fh: BinaryIO | StrOrBytesPath) -> tuple[int, int]:
     """Get the version of the ND2 file or raise an exception.
 
     Parameters
@@ -84,7 +84,7 @@ def get_version(fh: BufferedReader | StrOrBytesPath) -> tuple[int, int]:
     ValueError
         If the file is not a valid ND2 file or the header chunk is corrupt.
     """
-    if not isinstance(fh, BufferedReader):
+    if not isinstance(fh, (BinaryIO, BufferedReader)):
         with open(fh, "rb") as fh:
             chunk = START_FILE_CHUNK.unpack(fh.read(START_FILE_CHUNK.size))
     else:

--- a/src/nd2/_pysdk/_pysdk.py
+++ b/src/nd2/_pysdk/_pysdk.py
@@ -499,9 +499,8 @@ class ND2Reader:
 
     def _app_info(self) -> dict:
         """Return a dict of app info."""
-        if (k := b"CustomDataVar|AppInfo_V1_0!") in self.chunkmap:
-            return self._decode_chunk(k)
-        return {}
+        k = b"CustomDataVar|AppInfo_V1_0!"
+        return self._decode_chunk(k) if k in self.chunkmap else {}
 
     def _acquisition_date(self) -> datetime.datetime | str | None:
         """Try to extract acquisition date.
@@ -512,7 +511,8 @@ class ND2Reader:
         """
         from nd2._util import parse_time
 
-        if date := self.text_info().get("date"):
+        date = self.text_info().get("date")
+        if date:
             try:
                 return parse_time(date)
             except ValueError:

--- a/src/nd2/_pysdk/_pysdk.py
+++ b/src/nd2/_pysdk/_pysdk.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import mmap
+import os
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Sequence, cast
@@ -208,9 +209,8 @@ class ND2Reader:
                 text_info=self.text_info(),
             )
             if self._global_metadata["time"]["absoluteJulianDayNumber"] < 1:
-                # julian_day = os.stat(self._path).st_ctime / 86400.0 + 2440587.5
-                # self._global_metadata["time"]["absoluteJulianDayNumber"] = julian_day
-                self._global_metadata["time"]["absoluteJulianDayNumber"] = None
+                julian_day = os.stat(self._path).st_ctime / 86400.0 + 2440587.5
+                self._global_metadata["time"]["absoluteJulianDayNumber"] = julian_day
 
         return self._global_metadata
 

--- a/src/nd2/_util.py
+++ b/src/nd2/_util.py
@@ -121,3 +121,22 @@ class VoxelSize(NamedTuple):
     x: float
     y: float
     z: float
+
+
+TIME_FMT_STRINGS = [
+    "%m/%d/%Y %I:%M:%S %p",
+    "%d/%m/%Y %I:%M:%S",
+    "%Y-%m-%d %H:%M:%S",
+    "%d/%m/%Y %H:%M:%S",
+    "%d-%b-%y %I:%M:%S %p",
+    "%d/%m/%Y %I:%M:%S %p",
+]
+
+
+def parse_time(time_str: str) -> datetime:
+    for fmt_str in TIME_FMT_STRINGS:
+        try:
+            return datetime.strptime(time_str, fmt_str)
+        except ValueError:
+            continue
+    raise ValueError(f"Could not parse {time_str}")

--- a/src/nd2/index.py
+++ b/src/nd2/index.py
@@ -211,7 +211,7 @@ def _filter_data(
         # preserve order of to_include
         data = [{h: row[h] for h in to_include} for row in data]
 
-    to_exclude = cast(list[str], exclude.split(",") if exclude else [])
+    to_exclude = cast("list[str]", exclude.split(",") if exclude else [])
 
     if to_exclude:
         data = [{h: row[h] for h in HEADERS if h not in to_exclude} for row in data]

--- a/src/nd2/index.py
+++ b/src/nd2/index.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+import nd2
+
+
+def _index_file(path: Path) -> dict:
+    """Return a dict with the index file data."""
+    with nd2.ND2File(path) as nd:
+        stat = path.stat()
+
+        software = {} if nd.is_legacy else nd._rdr._app_info()  # type: ignore
+        acquired = "" if nd.is_legacy else nd._rdr._acquisition_date()  # type: ignore
+        exp = [(x.type, x.count) for x in nd.experiment]
+        axes, shape = zip(*nd.sizes.items())
+        return {
+            # "path": str(path.resolve()),
+            "name": path.name,
+            "nd2v": ".".join(map(str, nd.version)),
+            "size": stat.st_size,
+            # "modified": datetime.fromtimestamp(stat.st_mtime).isoformat(),
+            "created": datetime.fromtimestamp(stat.st_ctime).isoformat(),
+            "acquired": acquired,
+            "experiment": ";".join([f"{t}:{c}" for t, c in exp]),
+            "dtype": str(nd.dtype),
+            "shape": shape,
+            "axes": "".join(axes),
+            # "software_name": software.get("SWNameString", ""),
+            "software_version": software.get("VersionString", ""),
+            "grabber": software.get("GrabberString", ""),
+        }
+
+
+def _gather_files(
+    paths: Iterable[Path], recurse: bool = False, glob: str = "*.nd2"
+) -> Iterator[Path]:
+    """Return a generator of all files in the given path."""
+    for p in paths:
+        if p.is_dir():
+            yield from p.rglob(glob) if recurse else p.glob(glob)
+        else:
+            yield p
+
+
+def _index_files(
+    paths: Iterable[Path], recurse: bool = False, glob: str = "*.nd2"
+) -> list[dict]:
+    with ThreadPoolExecutor() as executor:
+        results = list(executor.map(_index_file, _gather_files(paths, recurse, glob)))
+
+    return results
+
+
+def _pretty_print_table(data: list[dict[str, Any]]) -> None:
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    table = Table(show_header=True, header_style="bold")
+
+    # Extract the keys from the first dictionary to create table headers
+    for header in data[0]:
+        table.add_column(header)
+
+    # Add data rows
+    for row in data:
+        table.add_row(*[str(value) for value in row.values()])
+
+    console.print(table)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="Path to ND2 file or directory containing ND2 files.",
+    )
+    parser.add_argument("--recurse", "-r", action="store_true")
+    parser.add_argument("--glob-pattern", "-g", default="*.nd2")
+    args = parser.parse_args()
+
+    data = _index_files(args.paths, args.recurse, args.glob_pattern)
+
+    _pretty_print_table(data)

--- a/src/nd2/index.py
+++ b/src/nd2/index.py
@@ -227,7 +227,7 @@ def main(argv: Sequence[str] = ()) -> None:
     """Index ND2 files and print the results as a table."""
     args = _parse_args(argv)
 
-    to_include = cast(list[str], args.include.split(",") if args.include else [])
+    to_include = cast("list[str]", args.include.split(",") if args.include else [])
     if args.sort_by and to_include and args.sort_by not in to_include:
         raise sys.exit(  # pragma: no cover
             f"The sort column {args.sort_by!r} must be in the "

--- a/src/nd2/index.py
+++ b/src/nd2/index.py
@@ -7,7 +7,9 @@ from argparse import RawTextHelpFormatter
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable, Iterator, Sequence, TypedDict, cast, no_type_check
+from typing import Iterable, Iterator, Sequence, cast, no_type_check
+
+from typing_extensions import TypedDict
 
 import nd2
 

--- a/src/nd2/index.py
+++ b/src/nd2/index.py
@@ -1,38 +1,77 @@
 from __future__ import annotations
 
+import argparse
+import json
+import sys
+from argparse import RawTextHelpFormatter
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Iterable, Iterator
+from typing import Iterable, Iterator, Sequence, TypedDict, cast, no_type_check
 
 import nd2
 
+try:
+    import rich
 
-def _index_file(path: Path) -> dict:
+    print = rich.print  # noqa: A001
+except ImportError:
+    rich = None
+
+
+class Record(TypedDict):
+    """Dict returned by `index_file`."""
+
+    path: str
+    name: str
+    version: str
+    kb: float
+    acquired: str
+    experiment: str
+    dtype: str
+    shape: list[int]
+    axes: str
+    software_name: str
+    software_version: str
+    grabber: str
+
+
+HEADERS = list(Record.__annotations__)
+TIME_FORMAT = "%Y-%m-%d %H:%M:%S"  # YYYY-MM-DD HH:MM:SS
+
+
+def index_file(path: Path) -> Record:
     """Return a dict with the index file data."""
     with nd2.ND2File(path) as nd:
-        stat = path.stat()
+        if nd.is_legacy:
+            software: dict = {}
+            acquired: str | None = ""
+        else:
+            software = nd._rdr._app_info()  # type: ignore
+            acquired = nd._rdr._acquisition_date()  # type: ignore
 
-        software = {} if nd.is_legacy else nd._rdr._app_info()  # type: ignore
-        acquired = "" if nd.is_legacy else nd._rdr._acquisition_date()  # type: ignore
+        stat = path.stat()
         exp = [(x.type, x.count) for x in nd.experiment]
         axes, shape = zip(*nd.sizes.items())
-        return {
-            # "path": str(path.resolve()),
-            "name": path.name,
-            "nd2v": ".".join(map(str, nd.version)),
-            "size": stat.st_size,
-            # "modified": datetime.fromtimestamp(stat.st_mtime).isoformat(),
-            "created": datetime.fromtimestamp(stat.st_ctime).isoformat(),
-            "acquired": acquired,
-            "experiment": ";".join([f"{t}:{c}" for t, c in exp]),
-            "dtype": str(nd.dtype),
-            "shape": shape,
-            "axes": "".join(axes),
-            # "software_name": software.get("SWNameString", ""),
-            "software_version": software.get("VersionString", ""),
-            "grabber": software.get("GrabberString", ""),
-        }
+        if isinstance(acquired, datetime):
+            acquired = acquired.strftime(TIME_FORMAT)
+
+        return Record(
+            {
+                "path": str(path.resolve()),
+                "name": path.name,
+                "version": ".".join(map(str, nd.version)),
+                "kb": round(stat.st_size / 1000, 2),
+                "acquired": acquired or "",
+                "experiment": ";".join([f"{t}:{c}" for t, c in exp]),
+                "dtype": str(nd.dtype),
+                "shape": list(shape),
+                "axes": "".join(axes),
+                "software_name": software.get("SWNameString", ""),
+                "software_version": software.get("VersionString", ""),
+                "grabber": software.get("GrabberString", ""),
+            }
+        )
 
 
 def _gather_files(
@@ -48,45 +87,164 @@ def _gather_files(
 
 def _index_files(
     paths: Iterable[Path], recurse: bool = False, glob: str = "*.nd2"
-) -> list[dict]:
+) -> list[Record]:
     with ThreadPoolExecutor() as executor:
-        results = list(executor.map(_index_file, _gather_files(paths, recurse, glob)))
+        results = list(executor.map(index_file, _gather_files(paths, recurse, glob)))
 
     return results
 
 
-def _pretty_print_table(data: list[dict[str, Any]]) -> None:
-    from rich.console import Console
-    from rich.table import Table
+def _pretty_print_table(data: list[Record]) -> None:
+    try:
+        from rich.console import Console
+        from rich.table import Table
+    except ImportError:
+        raise sys.exit(
+            "rich is required to print a pretty table. "
+            "Install it with `pip install rich`."
+        ) from None
 
-    console = Console()
     table = Table(show_header=True, header_style="bold")
 
-    # Extract the keys from the first dictionary to create table headers
     for header in data[0]:
         table.add_column(header)
-
-    # Add data rows
     for row in data:
         table.add_row(*[str(value) for value in row.values()])
 
-    console.print(table)
+    Console().print(table)
 
 
-if __name__ == "__main__":
-    import argparse
+def _print_csv(records: list[Record], skip_header: bool = False) -> None:
+    import csv
+    import sys
 
-    parser = argparse.ArgumentParser()
+    writer = csv.DictWriter(sys.stdout, fieldnames=records[0].keys())
+    if not skip_header:
+        writer.writeheader()
+    writer.writerows(records)
+
+
+def _print_json(records: list[Record]) -> None:
+    print(json.dumps(records, indent=2))
+
+
+def _parse_args(argv: Sequence[str] = ()) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        formatter_class=RawTextHelpFormatter,
+        description="Create an index of important metadata in ND2 files."
+        f"\n\nValid column names are:\n{HEADERS!r}",
+    )
     parser.add_argument(
         "paths",
         nargs="+",
         type=Path,
         help="Path to ND2 file or directory containing ND2 files.",
     )
-    parser.add_argument("--recurse", "-r", action="store_true")
-    parser.add_argument("--glob-pattern", "-g", default="*.nd2")
-    args = parser.parse_args()
+    parser.add_argument(
+        "--recurse",
+        "-r",
+        action="store_true",
+        default=False,
+        help="Recursively search directories",
+    )
+    parser.add_argument(
+        "--glob-pattern",
+        "-g",
+        type=str,
+        default="*.nd2",
+        help="Glob pattern to search for",
+    )
+    parser.add_argument(
+        "--sort-by",
+        "-s",
+        default="",
+        type=str,
+        choices=[*HEADERS, "", *(f"{x}-" for x in HEADERS)],
+        metavar="COLUMN_NAME",
+        help="Column to sort by. If not specified, the order is not guaranteed. "
+        "\nTo sort in reverse, append a hyphen.",
+    )
+    parser.add_argument(
+        "--format",
+        "-f",
+        default="table" if rich is not None else "json",
+        type=str,
+        choices=["table", "csv", "json"],
+    )
+    parser.add_argument(
+        "--include",
+        "-i",
+        type=str,
+        help="Comma-separated columns to include in the output",
+    )
+    parser.add_argument(
+        "--exclude",
+        "-e",
+        type=str,
+        help="Comma-separated columns to exclude in the output",
+    )
+    parser.add_argument(
+        "--no-header",
+        default=False,
+        action="store_true",
+        help="Don't write the CSV header",
+    )
 
-    data = _index_files(args.paths, args.recurse, args.glob_pattern)
+    return parser.parse_args(argv or sys.argv[1:])
 
-    _pretty_print_table(data)
+
+@no_type_check
+def _filter_data(
+    data: list[Record],
+    to_include: Sequence[str] = (),
+    sort_by: str | None = None,
+    exclude: str | None = None,
+) -> list[Record]:
+    if unrecognized := (set(to_include) - set(HEADERS)):  # pragma: no cover
+        print(f"Unrecognized columns: {', '.join(unrecognized)}", file=sys.stderr)
+        to_include = [x for x in to_include if x not in unrecognized]
+
+    if to_include:
+        # preserve order of to_include
+        data = [{h: row[h] for h in to_include} for row in data]
+
+    to_exclude = cast(list[str], exclude.split(",") if exclude else [])
+
+    if to_exclude:
+        data = [{h: row[h] for h in HEADERS if h not in to_exclude} for row in data]
+
+    if sort_by:
+        if sort_by.endswith("-"):
+            data.sort(key=lambda x: x[sort_by[:-1]], reverse=True)
+        else:
+            data.sort(key=lambda x: x[sort_by])
+
+    return data
+
+
+def main(argv: Sequence[str] = ()) -> None:
+    """Index ND2 files and print the results as a table."""
+    args = _parse_args(argv)
+
+    to_include = cast(list[str], args.include.split(",") if args.include else [])
+    if args.sort_by and to_include and args.sort_by not in to_include:
+        raise sys.exit(  # pragma: no cover
+            f"The sort column {args.sort_by!r} must be in the "
+            f"included columns: {to_include!r}."
+        )
+
+    data = _index_files(paths=args.paths, recurse=args.recurse, glob=args.glob_pattern)
+    data = _filter_data(
+        data, to_include=to_include, sort_by=args.sort_by, exclude=args.exclude
+    )
+
+    if args.format == "table":
+        _pretty_print_table(data)
+    elif args.format == "csv":
+        _print_csv(data, args.no_header)
+    elif args.format == "json":
+        _print_json(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nd2/index.py
+++ b/src/nd2/index.py
@@ -200,7 +200,8 @@ def _filter_data(
     sort_by: str | None = None,
     exclude: str | None = None,
 ) -> list[Record]:
-    if unrecognized := (set(to_include) - set(HEADERS)):  # pragma: no cover
+    unrecognized = set(to_include) - set(HEADERS)
+    if unrecognized:  # pragma: no cover
         print(f"Unrecognized columns: {', '.join(unrecognized)}", file=sys.stderr)
         to_include = [x for x in to_include if x not in unrecognized]
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,9 @@
+from nd2.index import _index_file
+
+
+def test_index_new(new_nd2):
+    assert isinstance(_index_file(new_nd2), dict)
+
+
+def test_index_legacy(old_nd2):
+    assert isinstance(_index_file(old_nd2), dict)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,9 +1,55 @@
-from nd2.index import _index_file
+from pathlib import Path
+
+import nd2.index
+import pytest
+
+DATA = (Path(__file__).parent / "data").resolve()
 
 
-def test_index_new(new_nd2):
-    assert isinstance(_index_file(new_nd2), dict)
+@pytest.fixture(scope="module")
+def records():
+    return list(nd2.index._index_files([DATA, DATA / "cluster.nd2"]))
 
 
-def test_index_legacy(old_nd2):
-    assert isinstance(_index_file(old_nd2), dict)
+@pytest.mark.parametrize("fmt", ["csv", "json", "table"])
+def test_format(records, fmt, capsys):
+    filtered = nd2.index._filter_data(records)
+
+    if fmt == "table":
+        nd2.index._pretty_print_table(filtered)
+    elif fmt == "csv":
+        nd2.index._print_csv(filtered)
+    elif fmt == "json":
+        nd2.index._print_json(filtered)
+    captured = capsys.readouterr()
+    assert "path" in captured.out
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {},
+        {"to_include": ["path", "name", "version"]},
+        {"sort_by": "version"},
+        {"sort_by": "version-"},
+        {"exclude": "path"},
+    ],
+)
+def test_filter_data(records, filters: dict):
+    filtered = nd2.index._filter_data(records, **filters)
+    assert isinstance(filtered, list)
+    assert len(filtered) == len(records)
+    if filters.get("to_include"):
+        assert len(filtered[0]) == len(filters["to_include"])
+    if sb := filters.get("sort_by"):
+        first_version = filtered[0]["version"]
+        # ascending / descending
+        assert first_version == "3.0" if sb.endswith("-") else "1.0"
+    if filters.get("exclude"):
+        assert "path" not in filtered[0]
+
+
+def test_index(capsys):
+    nd2.index.main([str(DATA), "--format", "csv"])
+    captured = capsys.readouterr()
+    assert "path" in captured.out

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -41,7 +41,8 @@ def test_filter_data(records, filters: dict):
     assert len(filtered) == len(records)
     if filters.get("to_include"):
         assert len(filtered[0]) == len(filters["to_include"])
-    if sb := filters.get("sort_by"):
+    sb = filters.get("sort_by")
+    if sb:
         first_version = filtered[0]["version"]
         # ascending / descending
         assert first_version == "3.0" if sb.endswith("-") else "1.0"


### PR DESCRIPTION
outputs something like this:

```
$ python -m nd2.index tests/data
```
<img width="1883" alt="Screen Shot 2023-06-24 at 1 29 17 PM" src="https://github.com/tlambert03/nd2/assets/1609449/9b854822-f308-41d0-b80e-3ec5cce39c6f">

```
usage: index.py [-h] [--recurse] [--glob-pattern GLOB_PATTERN]
                [--sort-by COLUMN_NAME] [--format {table,csv,json}]
                [--include INCLUDE] [--exclude EXCLUDE] [--no-header]
                paths [paths ...]

Create an index of important metadata in ND2 files.

Valid column names are:
['path', 'name', 'version', 'kb', 'acquired', 'experiment', 'dtype', 'shape', 'axes',
'software_name', 'software_version', 'grabber']

positional arguments:
  paths                 Path to ND2 file or directory containing ND2 files.

options:
  -h, --help            show this help message and exit
  --recurse, -r         Recursively search directories
  --glob-pattern GLOB_PATTERN, -g GLOB_PATTERN
                        Glob pattern to search for
  --sort-by COLUMN_NAME, -s COLUMN_NAME
                        Column to sort by. If not specified, the order is not guaranteed.
                        To sort in reverse, append a hyphen.
  --format {table,csv,json}, -f {table,csv,json}
  --include INCLUDE, -i INCLUDE
                        Comma-separated columns to include in the output
  --exclude EXCLUDE, -e EXCLUDE
                        Comma-separated columns to exclude in the output
  --no-header           Don't write the CSV header

```