### PR TITLE
feat: decode compressed lite variant, and read string type tags

### DIFF
--- a/scripts/download_samples.py
+++ b/scripts/download_samples.py
@@ -11,10 +11,10 @@ URL = "https://www.dropbox.com/sh/pg9my6hnjj918x8/AACiKLlcDsljRgjJOec-9PQwa?dl=1
 
 # this is just here to invalidate the github actions cache
 # change it when a new file is added to the test data in the dropbox folder
-__HASH__ = "2b6b31e6-8606-42c4-9011-5e233581e53b"
+__HASH__ = "a1b2c3d4-e5f6-g7h8-i9j0-k1l2m3n4o5p6"
 
 
-def main():
+def main() -> None:
     response = requests.get(URL, stream=True)
     total_length = response.headers.get("content-length")
 

--- a/src/nd2/_binary.py
+++ b/src/nd2/_binary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import io
 import struct
 import warnings
+import zlib
 from typing import TYPE_CHECKING, Iterator, NamedTuple, Sequence, cast, overload
 
 import numpy as np
@@ -220,8 +221,6 @@ def _decode_binary_mask(data: bytes, dtype: DTypeLike = "uint16") -> np.ndarray:
 
     # NOTE it is up to ND2File to strip the first 4 bytes... and not call this if there
     # is no data (i.e. if the chunk is just '\x00')
-    import zlib
-
     decomp = zlib.decompress(data)
     stream = io.BytesIO(decomp)
 

--- a/src/nd2/_pysdk/_pysdk.py
+++ b/src/nd2/_pysdk/_pysdk.py
@@ -533,7 +533,7 @@ class ND2Reader:
                     for i in range(count):
                         word = buffer_[i * chunk_size : (i + 1) * chunk_size]
                         rows.append(word.decode("utf-16").split("\x00", 1)[0])
-                except Exception as e:
+                except Exception as e:  # pragma: no cover
                     warnings.warn(
                         f"Failed to parse {tag['Desc']!r} column: {e}. Please open an "
                         "issue with this nd2 file at "

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -175,3 +175,10 @@ def test_events(new_nd2: Path, orient: Literal["records", "dict", "list"]) -> No
 
     pd = pytest.importorskip("pandas")
     print(pd.DataFrame(events))
+
+
+def test_compressed_metadata() -> None:
+    with ND2File(DATA / "rois.nd2") as f:
+        chunk = f._rdr._decode_chunk(b"CustomData|CustomDescriptionV1_0!")
+        assert "CLxCustomDescription" in chunk
+        assert "Name" in chunk["CLxCustomDescription"]


### PR DESCRIPTION
This PR parses and includes string columns found in the CustomData chunks (which were previously skipped, lacking good examples).

It also now deflates and parses compressed lite variant data chunks
