### PR TITLE
feat: accept file handles as well as paths

### DIFF
--- a/src/nd2/_util.py
+++ b/src/nd2/_util.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
 
     from nd2.readers import ND2Reader
 
-    StrOrBytesPath = Union[str, bytes, PathLike[str], PathLike[bytes]]
+    StrOrPath = Union[str, PathLike]
+    FileOrBinaryIO = Union[StrOrPath, BinaryIO]
 
     ListOfDicts = list[dict[str, Any]]
     DictOfLists = Mapping[str, Sequence[Any]]
@@ -24,13 +25,13 @@ OLD_HEADER_MAGIC = b"\x00\x00\x00\x0c"
 VERSION = re.compile(r"^ND2 FILE SIGNATURE CHUNK NAME01!Ver([\d\.]+)$")
 
 
-def _open_binary(path: StrOrBytesPath) -> BinaryIO:
+def _open_binary(path: StrOrPath) -> BinaryIO:
     return open(path, "rb")
 
 
 def is_supported_file(
-    path: StrOrBytesPath | BinaryIO,
-    open_: Callable[[StrOrBytesPath], BinaryIO] = _open_binary,
+    path: FileOrBinaryIO,
+    open_: Callable[[StrOrPath], BinaryIO] = _open_binary,
 ) -> bool:
     """Return `True` if `path` can be opened as an nd2 file.
 
@@ -55,7 +56,7 @@ def is_supported_file(
     return magic in (NEW_HEADER_MAGIC, OLD_HEADER_MAGIC)
 
 
-def is_legacy(path: StrOrBytesPath) -> bool:
+def is_legacy(path: StrOrPath) -> bool:
     """Return `True` if `path` is a legacy ND2 file.
 
     Parameters

--- a/src/nd2/nd2file.py
+++ b/src/nd2/nd2file.py
@@ -29,7 +29,13 @@ if TYPE_CHECKING:
     from typing_extensions import Literal
 
     from ._binary import BinaryLayers
-    from ._util import DictOfDicts, DictOfLists, ListOfDicts, StrOrBytesPath
+    from ._util import (
+        DictOfDicts,
+        DictOfLists,
+        FileOrBinaryIO,
+        ListOfDicts,
+        StrOrPath,
+    )
     from .structures import (
         ROI,
         Attributes,
@@ -90,7 +96,7 @@ class ND2File:
 
     def __init__(
         self,
-        path: Path | str,
+        path: FileOrBinaryIO,
         *,
         validate_frames: bool = False,
         search_window: int = 100,
@@ -108,11 +114,10 @@ class ND2File:
         )
         self._rdr = ND2Reader.create(path, self._error_radius)
         self._path = self._rdr._path
-        self._closed = False
         self._lock = threading.RLock()
 
     @staticmethod
-    def is_supported_file(path: StrOrBytesPath) -> bool:
+    def is_supported_file(path: StrOrPath) -> bool:
         """Return `True` if the file is supported by this reader."""
         return is_supported_file(path)
 
@@ -165,7 +170,6 @@ class ND2File:
         """
         if self.closed:
             self._rdr.open()
-            self._closed = False
 
     def close(self) -> None:
         """Close file.
@@ -183,12 +187,11 @@ class ND2File:
         """
         if not self.closed:
             self._rdr.close()
-            self._closed = True
 
     @property
     def closed(self) -> bool:
         """Return `True` if the file is closed."""
-        return self._closed
+        return self._rdr._closed
 
     def __enter__(self) -> ND2File:
         """Open file for reading."""
@@ -197,7 +200,8 @@ class ND2File:
 
     def __del__(self) -> None:
         """Delete file handle on garbage collection."""
-        if not getattr(self, "_closed", True):
+        # if it came in as an open file handle, it's ok to remain open after deletion
+        if not getattr(self, "closed", True) and not self._rdr._was_open:
             warnings.warn(
                 "ND2File file not closed before garbage collection. "
                 "Please use `with ND2File(...):` context or call `.close()`.",
@@ -214,15 +218,17 @@ class ND2File:
         state = self.__dict__.copy()
         del state["_rdr"]
         del state["_lock"]
+        state["_closed"] = self.closed
         return state
 
     def __setstate__(self, d: dict[str, Any]) -> None:
         """Load state from pickling."""
+        _was_closed = d.pop("_closed", False)
         self.__dict__ = d
         self._lock = threading.RLock()
         self._rdr = ND2Reader.create(self._path, self._error_radius)
 
-        if self._closed:
+        if _was_closed:
             self._rdr.close()
 
     @cached_property

--- a/src/nd2/nd2file.py
+++ b/src/nd2/nd2file.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 import threading
 import warnings
 from itertools import product
-from pathlib import Path
 from typing import TYPE_CHECKING, cast, overload
 
 import numpy as np
 
 from nd2 import _util
 
-from ._parse._chunk_decode import get_version
 from ._util import AXIS, is_supported_file
 from .readers.protocol import ND2Reader
 
@@ -21,6 +19,7 @@ except ImportError:
 
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from typing import Any, Sequence, Sized, SupportsInt
 
     import dask.array
@@ -104,11 +103,11 @@ class ND2File:
                 FutureWarning,
                 stacklevel=2,
             )
-        self._path = str(path)
         self._error_radius: int | None = (
             search_window * 1000 if validate_frames else None
         )
-        self._rdr = ND2Reader.create(self._path, self._error_radius)
+        self._rdr = ND2Reader.create(path, self._error_radius)
+        self._path = self._rdr._path
         self._closed = False
         self._lock = threading.RLock()
 
@@ -138,12 +137,12 @@ class ND2File:
         ValueError
             If the file is not a valid nd2 file.
         """
-        return get_version(self._path)
+        return self._rdr.version()
 
     @property
     def path(self) -> str:
         """Path of the image."""
-        return self._path
+        return str(self._path)
 
     @property
     def is_legacy(self) -> bool:
@@ -1119,7 +1118,7 @@ class ND2File:
         """Return a string representation of the ND2File."""
         try:
             details = " (closed)" if self.closed else f" {self.dtype}: {self.sizes!r}"
-            extra = f": {Path(self.path).name!r}{details}"
+            extra = f": {self._path.name!r}{details}"
         except Exception:
             extra = ""
         return f"<ND2File at {hex(id(self))}{extra}>"

--- a/src/nd2/readers/_legacy/legacy_reader.py
+++ b/src/nd2/readers/_legacy/legacy_reader.py
@@ -6,7 +6,7 @@ import struct
 import threading
 import warnings
 from dataclasses import replace
-from typing import TYPE_CHECKING, Any, BinaryIO, DefaultDict, Mapping, cast
+from typing import TYPE_CHECKING, DefaultDict, cast
 
 import numpy as np
 
@@ -22,8 +22,8 @@ except ImportError:
 
 if TYPE_CHECKING:
     from collections import defaultdict
-    from io import BufferedReader
     from pathlib import Path
+    from typing import Any, BinaryIO, Mapping
 
     from typing_extensions import TypedDict
 
@@ -143,7 +143,9 @@ IHDR = struct.Struct(">iihBB")  # yxc-dtype in jpeg 2000
 class LegacyReader(ND2Reader):
     HEADER_MAGIC = _util.OLD_HEADER_MAGIC
 
-    def __init__(self, path: str | Path, error_radius: int | None = None) -> None:
+    def __init__(
+        self, path: str | Path | BinaryIO, error_radius: int | None = None
+    ) -> None:
         super().__init__(path, error_radius)
         self._attributes: strct.Attributes | None = None
         # super().__init__ called open()
@@ -415,7 +417,7 @@ class LegacyReader(ND2Reader):
             pos = self.chunkmap[b"jp2h"][0]
         except (KeyError, IndexError) as e:
             raise KeyError("No valid jp2h header found in file") from e
-        fh = cast("BufferedReader", self._fh)
+        fh = cast("BinaryIO", self._fh)
         fh.seek(pos + I4s.size + 4)  # 4 bytes for "label"
         if fh.read(4) != b"ihdr":
             raise KeyError("No valid ihdr header found in jp2h header")

--- a/src/nd2/readers/_legacy/legacy_reader.py
+++ b/src/nd2/readers/_legacy/legacy_reader.py
@@ -22,10 +22,11 @@ except ImportError:
 
 if TYPE_CHECKING:
     from collections import defaultdict
-    from pathlib import Path
     from typing import Any, BinaryIO, Mapping
 
     from typing_extensions import TypedDict
+
+    from nd2._util import FileOrBinaryIO
 
     class RawExperimentLoop(TypedDict, total=False):
         Type: int
@@ -143,9 +144,7 @@ IHDR = struct.Struct(">iihBB")  # yxc-dtype in jpeg 2000
 class LegacyReader(ND2Reader):
     HEADER_MAGIC = _util.OLD_HEADER_MAGIC
 
-    def __init__(
-        self, path: str | Path | BinaryIO, error_radius: int | None = None
-    ) -> None:
+    def __init__(self, path: FileOrBinaryIO, error_radius: int | None = None) -> None:
         super().__init__(path, error_radius)
         self._attributes: strct.Attributes | None = None
         # super().__init__ called open()

--- a/src/nd2/readers/_modern/modern_reader.py
+++ b/src/nd2/readers/_modern/modern_reader.py
@@ -4,7 +4,7 @@ import os
 import warnings
 import zlib
 from itertools import product
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence, cast
+from typing import TYPE_CHECKING, Any, BinaryIO, Iterable, Mapping, Sequence, cast
 
 import numpy as np
 
@@ -55,7 +55,9 @@ if TYPE_CHECKING:
 class ModernReader(ND2Reader):
     HEADER_MAGIC = _util.NEW_HEADER_MAGIC
 
-    def __init__(self, path: str | Path, error_radius: int | None = None) -> None:
+    def __init__(
+        self, path: str | Path | BinaryIO, error_radius: int | None = None
+    ) -> None:
         super().__init__(path, error_radius)
 
         self._cached_decoded_chunks: dict[bytes, Any] = {}

--- a/src/nd2/readers/_modern/modern_reader.py
+++ b/src/nd2/readers/_modern/modern_reader.py
@@ -4,7 +4,7 @@ import os
 import warnings
 import zlib
 from itertools import product
-from typing import TYPE_CHECKING, Any, BinaryIO, Iterable, Mapping, Sequence, cast
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence, cast
 
 import numpy as np
 
@@ -32,7 +32,6 @@ from nd2.structures import ROI
 if TYPE_CHECKING:
     import datetime
     from os import PathLike
-    from pathlib import Path
 
     from typing_extensions import Literal, TypeAlias
 
@@ -47,6 +46,7 @@ if TYPE_CHECKING:
         RawTagDict,
         RawTextInfoDict,
     )
+    from nd2._util import FileOrBinaryIO
 
     StrOrBytesPath: TypeAlias = str | bytes | PathLike[str] | PathLike[bytes]
     StartFileChunk: TypeAlias = tuple[int, int, int, bytes, bytes]
@@ -55,9 +55,7 @@ if TYPE_CHECKING:
 class ModernReader(ND2Reader):
     HEADER_MAGIC = _util.NEW_HEADER_MAGIC
 
-    def __init__(
-        self, path: str | Path | BinaryIO, error_radius: int | None = None
-    ) -> None:
+    def __init__(self, path: FileOrBinaryIO, error_radius: int | None = None) -> None:
         super().__init__(path, error_radius)
 
         self._cached_decoded_chunks: dict[bytes, Any] = {}

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -265,3 +265,14 @@ def test_gc_triggers_cleanup(single_nd2):
     with pytest.warns(UserWarning, match="ND2File file not closed"):
         f = None  # noqa: F841
         gc.collect()
+
+
+def test_file_handles(single_nd2: Path) -> None:
+    """Test that we can open a file with a file handle also"""
+    with open(single_nd2, "rb") as fh:
+        f = ND2File(fh)
+        assert f.path == str(single_nd2)
+        assert f.version == (3, 0)
+        assert isinstance(f.asarray(), np.ndarray)
+    assert fh.closed
+    assert f.closed


### PR DESCRIPTION
this makes it possible to use:

```py
with open('myfile.nd2', 'rb') as fh:
    nd2file = nd2.ND2File(fh)
```

closes #1 