### PR TITLE
refactor: make binarylayer a dataclass

### DIFF
--- a/src/nd2/_binary.py
+++ b/src/nd2/_binary.py
@@ -20,7 +20,7 @@ I9 = struct.Struct("<" + "I" * 9)
 I2 = struct.Struct("<" + "I" * 2)
 
 SLOTS = {}
-if sys.version_info >= (3, 9):
+if sys.version_info >= (3, 10):
     SLOTS["slots"] = True
 
 

--- a/src/nd2/nd2file.py
+++ b/src/nd2/nd2file.py
@@ -1162,6 +1162,8 @@ class ND2File:
         attribute which is list of numpy arrays (or `None` if there was no binary mask
         for that frame).  The length of the list will be the same as the number of
         sequence frames in this file (i.e. `self.attributes.sequenceCount`).
+        `BinaryLayers` can be indexed directly with an integer corresponding to the
+        *frame* index.
 
         Both the `BinaryLayers` and individual `BinaryLayer` objects can be cast to a
         numpy array with `np.asarray()`, or by using the `.asarray()` method

--- a/src/nd2/nd2file.py
+++ b/src/nd2/nd2file.py
@@ -1155,11 +1155,13 @@ class ND2File:
         """Return binary layers embedded in the file.
 
         The returned `BinaryLayers` object is an immutable sequence of `BinaryLayer`
-        objects, one for each binary layer in the file.  Each `BinaryLayer` object in
-        the sequence has a `name` attribute, and a `data` attribute which is list of
-        numpy arrays (or `None` if there was no binary mask for that frame).  The length
-        of the list will be the same as the number of sequence frames in this file
-        (i.e. `self.attributes.sequenceCount`).
+        objects, one for each binary layer in the file (there will usually be a binary
+        layer associated with each channel in the dataset).
+
+        Each `BinaryLayer` object in the sequence has a `name` attribute, and a `data`
+        attribute which is list of numpy arrays (or `None` if there was no binary mask
+        for that frame).  The length of the list will be the same as the number of
+        sequence frames in this file (i.e. `self.attributes.sequenceCount`).
 
         Both the `BinaryLayers` and individual `BinaryLayer` objects can be cast to a
         numpy array with `np.asarray()`, or by using the `.asarray()` method
@@ -1175,12 +1177,15 @@ class ND2File:
         >>> f = ND2File("path/to/file.nd2")
         >>> f.binary_data
         <BinaryLayers with 4 layers>
-        >>> f.binary_data[0]  # the first binary layer
+        >>> first_layer = f.binary_data[0]  # the first binary layer
+        >>> first_layer
         BinaryLayer(name='attached Widefield green (green color)',
         comp_name='Widefield Green', comp_order=2, color=65280, color_mode=0,
         state=524288, file_tag='RleZipBinarySequence_1_v1', layer_id=2)
-        >>> f.binary_data[0].data  # list of arrays
-        >>> np.asarray(f.binary_data[0])  # just the first binary mask
+        >>> first_layer.data  # list of arrays
+        # you can also index in to the BinaryLayers object itself
+        >>> first_layer[0]  # get binary data for first frame (or None if missing)
+        >>> np.asarray(first_layer)  # cast to array matching shape of full sequence
         >>> np.asarray(f.binary_data).shape  # cast all layers to array
         (4, 3, 4, 5, 32, 32)
         """

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -2,17 +2,30 @@ from pathlib import Path
 
 import nd2
 import numpy as np
+import numpy.testing as npt
 
 DATA = Path(__file__).parent / "data"
+
+# fmt: off
+ROW0 = [0,0,1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0,2,2,2,0,0,0,3,0,0,0,0,0,0,0]
+# fmt: on
 
 
 def test_binary():
     with nd2.ND2File(DATA / "with_binary_and_rois.nd2") as f:
         binlayers = f.binary_data
+        repr(binlayers)
+        repr(binlayers[0])
         assert binlayers is not None
         assert len(binlayers) == 4
         assert binlayers[0].name == "attached Widefield green (green color)"
-        assert len(binlayers[0].data) == f.attributes.sequenceCount
+        assert len(binlayers[0]) == f.attributes.sequenceCount
+        # you can index into the data
+        npt.assert_array_equal(binlayers[0].data[2][0], ROW0)
+        # you can also index a BinaryLayer directly
+        assert isinstance(binlayers[0][2], np.ndarray)
+        assert binlayers[0][3] is None
+        npt.assert_array_equal(binlayers[0][2][0], ROW0)
         ary = np.asarray(binlayers)
         assert ary.shape == (4, 3, 4, 5, 32, 32)
         assert ary.sum() == 172947


### PR DESCRIPTION
This makes it easier to add a `__getitem__` method to BinaryLayer that directly indexes the `data` attribute