### PR TITLE
feat: access more frames via direct read_frame() method

### DIFF
--- a/src/nd2/readers/_modern/modern_reader.py
+++ b/src/nd2/readers/_modern/modern_reader.py
@@ -315,9 +315,9 @@ class ModernReader(ND2Reader):
 
         # sometimes a frame index has a valid offset even if it's greater than
         # _seq_count() (for example, if experiment parsing misses stuff)
-        # so, it sould still be accessible.        
+        # so, it should still be accessible.
         if (offset := self._frame_offsets.get(index, None)) is None:
-            if index > self._seq_count():
+            if index > self._seq_count():  # pragma: no cover
                 raise IndexError(f"Frame out of range: {index}")
             return self._missing_frame(index)
 

--- a/src/nd2/readers/_modern/modern_reader.py
+++ b/src/nd2/readers/_modern/modern_reader.py
@@ -316,7 +316,8 @@ class ModernReader(ND2Reader):
         # sometimes a frame index has a valid offset even if it's greater than
         # _seq_count() (for example, if experiment parsing misses stuff)
         # so, it should still be accessible.
-        if (offset := self._frame_offsets.get(index, None)) is None:
+        offset = self._frame_offsets.get(index, None)
+        if offset is None:
             if index > self._seq_count():  # pragma: no cover
                 raise IndexError(f"Frame out of range: {index}")
             return self._missing_frame(index)

--- a/src/nd2/readers/_modern/modern_reader.py
+++ b/src/nd2/readers/_modern/modern_reader.py
@@ -310,12 +310,15 @@ class ModernReader(ND2Reader):
 
     def read_frame(self, index: int) -> np.ndarray:
         """Read a chunk directly without using SDK."""
-        if index > self._seq_count():
-            raise IndexError(f"Frame out of range: {index}")
         if not self._fh:  # pragma: no cover
             raise ValueError("Attempt to read from closed nd2 file")
-        offset = self._frame_offsets.get(index, None)
-        if offset is None:
+
+        # sometimes a frame index has a valid offset even if it's greater than
+        # _seq_count() (for example, if experiment parsing misses stuff)
+        # so, it sould still be accessible.        
+        if (offset := self._frame_offsets.get(index, None)) is None:
+            if index > self._seq_count():
+                raise IndexError(f"Frame out of range: {index}")
             return self._missing_frame(index)
 
         if self.attributes().compressionType == "lossless":

--- a/x.py
+++ b/x.py
@@ -1,9 +1,0 @@
-
-import nd2
-
-with nd2.ND2File("/Users/talley/Downloads/2023-09-11_MLY003_Cpf1.nd2") as f:
-    print(f.experiment)
-    print(f.attributes)
-    # print(f._rdr._raw_experiment)
-    print(f.read_frame(1000))
-    breakpoint()


### PR DESCRIPTION
the file in #190 revealed a case where sometimes there are more frames available and readable than the product of the experiment axes.  This PR makes those frames accessible by slightly relaxing the logic of the reader read_frame method.