### PR TITLE
[WIP] feat: add to_ome_tif method

### DIFF
--- a/src/nd2/nd2file.py
+++ b/src/nd2/nd2file.py
@@ -1226,8 +1226,15 @@ class ND2File:
                 if round(plane.position_x, 4) == x and round(plane.position_y, 4) == y:
                     pl_list.append(plane)
 
+            # update pixels channels samples_per_pixel
+            update_channels = {"samples_per_pixel": 1}
+            channels = []
+            for ch in image.pixels.channels:
+                channels.append(ch.model_copy(update=update_channels))
+
             # copy pixels and update
             update_pixels = {
+                "channels": channels,
                 "planes": pl_list,
                 "type": dask_ary.dtype.name,
                 "tiff_data_blocks": [TiffData(plane_count=len(pl_list))],

--- a/src/nd2/nd2file.py
+++ b/src/nd2/nd2file.py
@@ -47,7 +47,6 @@ if TYPE_CHECKING:
         FrameMetadata,
         Metadata,
         TextInfo,
-        XYPosLoop,
     )
 
 __all__ = ["ND2File", "imread"]
@@ -1184,8 +1183,10 @@ class ND2File:
                 # maybe find a better way. If 'T' in sizes, the 'P' index is the
                 # second index, else it's the first
                 data = (
-                    self.to_dask() if num_p == 1
-                    else self.to_dask()[:, p] if self.sizes.get("T")
+                    self.to_dask()
+                    if num_p == 1
+                    else self.to_dask()[:, p]
+                    if self.sizes.get("T")
                     else self.to_dask()[p]
                 )
 
@@ -1215,7 +1216,6 @@ class ND2File:
         new_ome_images: list[Image] = []
 
         for index, pos in enumerate(positions):
-
             # this is one way to group the planes by x, y position. Probably not the
             # best way to do it. Find a better way
             x, y = round(pos.stagePositionUm.x, 4), round(pos.stagePositionUm.y, 4)

--- a/tests/test_to_ome_tif.py
+++ b/tests/test_to_ome_tif.py
@@ -1,0 +1,26 @@
+import tempfile
+from pathlib import Path
+
+import nd2
+import tifffile
+
+
+def test_to_ome_tif(any_nd2: Path) -> None:
+
+    with tempfile.TemporaryDirectory() as tmp:
+        dest = Path(tmp) / "test.ome.tif"
+        n_pos = 1
+        with nd2.ND2File(any_nd2) as nd2_file:
+
+            # temporary fix for is_legacy and ValueError
+            if nd2_file.is_legacy:
+                return
+            for sz in nd2_file.sizes:
+                if sz not in ["X", "Y", "Z", "C", "P", "T"]:
+                    return
+
+            n_pos = nd2_file.sizes.get("P", 1)
+            nd2_file.to_ome_tif(dest)
+
+        with tifffile.TiffFile(dest) as tif:
+            assert len(tif.series) == n_pos

--- a/tests/test_to_ome_tif.py
+++ b/tests/test_to_ome_tif.py
@@ -6,12 +6,10 @@ import tifffile
 
 
 def test_to_ome_tif(any_nd2: Path) -> None:
-
     with tempfile.TemporaryDirectory() as tmp:
         dest = Path(tmp) / "test.ome.tif"
         n_pos = 1
         with nd2.ND2File(any_nd2) as nd2_file:
-
             # temporary fix for is_legacy and ValueError
             if nd2_file.is_legacy:
                 return


### PR DESCRIPTION
Hey @tlambert03 , I've started working on the conversion of the `nd2` files into the `ome-tif` format. It is definitely not finished but I think is a good starting point.

I've added a `to_ome_tif()` method to the package to save to disk na `.ome.tif` file and it is working as I want which means the I can also open the `.ome.tif` files in Fiji and properly load the `ome` metadata (also with multi position files - in this case the `bio-formats` importer asks the user to choose which series to open).

One thing that I understood is that we need to rearrange the `ome` metadata gathered form the `nd2` `ome_metadata()` method to create as many `Image` objects as the number of positions (grouped by the x, y position). At the moment this is done with the `_reorganize_metadata()` function that I've added but maybe we can do that directly in `ome_metadata()`.

When you have time can you have a look?

At the moment the test I've added only assert that the number of series in the tiff file is correct but it should be expanded as well.