### PR TITLE
feat: better color object

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,13 @@ Metadata(
     contents=Contents(channelCount=2, frameCount=60),
     channels=[
         Channel(
-            channel=ChannelMeta(name='Widefield Green', index=0, colorRGB=65371, emissionLambdaNm=535.0, excitationLambdaNm=None),
+            channel=ChannelMeta(
+                name='Widefield Green',
+                index=0,
+                color=Color(r=91, g=255, b=0, a=1.0),
+                emissionLambdaNm=535.0,
+                excitationLambdaNm=None
+            ),
             loops=LoopIndices(NETimeLoop=None, TimeLoop=0, XYPosLoop=1, ZStackLoop=2),
             microscope=Microscope(
                 objectiveMagnification=10.0,
@@ -204,7 +210,13 @@ Metadata(
             )
         ),
         Channel(
-            channel=ChannelMeta(name='Widefield Red', index=1, colorRGB=22015, emissionLambdaNm=620.0, excitationLambdaNm=None),
+            channel=ChannelMeta(
+                name='Widefield Red',
+                index=1,
+                color=Color(r=255, g=85, b=0, a=1.0),
+                emissionLambdaNm=620.0,
+                excitationLambdaNm=None
+            ),
             loops=LoopIndices(NETimeLoop=None, TimeLoop=0, XYPosLoop=1, ZStackLoop=2),
             microscope=Microscope(
                 objectiveMagnification=10.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ filterwarnings = [
     "ignore:The distutils package is deprecated::",
     "ignore:The distutils.sysconfig module is deprecated::",
     "ignore:distutils Version classes are deprecated:",
+    "ignore:::xarray",
 ]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/scripts/nd2_describe.py
+++ b/scripts/nd2_describe.py
@@ -10,6 +10,7 @@ from dataclasses import asdict
 from pathlib import Path
 
 import nd2
+from nd2 import structures
 from nd2._parse._chunk_decode import iter_chunks
 
 
@@ -34,6 +35,10 @@ def get_nd2_stats(path: Path) -> "tuple[str, dict]":
     with nd2.ND2File(path) as nd:
         meta = nd.metadata if isinstance(nd.metadata, dict) else asdict(nd.metadata)
         for channel in meta.get("channels", []):
+            # we changed colorRGB to color inb v0.10.0
+            if color := channel["channel"].pop("color", None):
+                if isinstance(color, structures.Color):
+                    channel["channel"]["colorRGB"] = color.as_abgr_u4()
             # Remove custom loops if null... they're super rare, and
             # readlimfile.json doesn't include them
             if channel.get("loops") and not channel["loops"].get("CustomLoop"):

--- a/src/nd2/_ome.py
+++ b/src/nd2/_ome.py
@@ -104,7 +104,7 @@ def nd2_ome_metadata(
         if not f.is_rgb:
             # if you include any of this for RGB images, the Bioformats OMETiffReader
             # will show all three RGB channels with the same color
-            channel.color = m.Color(ch.channel.rgba_tuple())
+            channel.color = m.Color(ch.channel.color)
             channel.emission_wavelength = ch.channel.emissionLambdaNm
             channel.emission_wavelength_unit = UnitsLength.NANOMETER
             channel.excitation_wavelength = ch.channel.excitationLambdaNm

--- a/src/nd2/_parse/_parse.py
+++ b/src/nd2/_parse/_parse.py
@@ -568,7 +568,7 @@ def load_metadata(raw_meta: RawMetaDict, global_meta: GlobalMetadata) -> strct.M
         channel_meta = strct.ChannelMeta(
             index=k,
             name=plane.get("sDescription", ""),
-            colorRGB=plane.get("uiColor", 0),
+            color=strct.Color.from_abgr_u4(plane.get("uiColor", 0)),
             emissionLambdaNm=em or None,
             excitationLambdaNm=ex or None,
         )

--- a/src/nd2/nd2file.py
+++ b/src/nd2/nd2file.py
@@ -442,7 +442,7 @@ class ND2File:
                         channel=ChannelMeta(
                             name="Widefield Green",
                             index=0,
-                            colorRGB=65371,
+                            color=Color(r=91, g=255, b=0, a=1.0),
                             emissionLambdaNm=535.0,
                             excitationLambdaNm=None,
                         ),
@@ -483,7 +483,7 @@ class ND2File:
                         channel=ChannelMeta(
                             name="Widefield Red",
                             index=1,
-                            colorRGB=22015,
+                            color=Color(r=255, g=85, b=0, a=1.0),
                             emissionLambdaNm=620.0,
                             excitationLambdaNm=None,
                         ),
@@ -549,7 +549,7 @@ class ND2File:
                         channel=ChannelMeta(
                             name="Widefield Green",
                             index=0,
-                            colorRGB=65371,
+                            color=Color(r=91, g=255, b=0, a=1.0),
                             emissionLambdaNm=535.0,
                             excitationLambdaNm=None,
                         ),
@@ -601,7 +601,7 @@ class ND2File:
                         channel=ChannelMeta(
                             name="Widefield Red",
                             index=1,
-                            colorRGB=22015,
+                            color=Color(r=255, g=85, b=0, a=1.0),
                             emissionLambdaNm=620.0,
                             excitationLambdaNm=None,
                         ),

--- a/src/nd2/readers/_legacy/legacy_reader.py
+++ b/src/nd2/readers/_legacy/legacy_reader.py
@@ -527,7 +527,7 @@ def _load_metadata(
         channel_meta = strct.ChannelMeta(
             name=plane["OpticalConfigName"],
             index=int(idx),
-            colorRGB=plane["Color"],
+            color=strct.Color.from_abgr_u4(plane["Color"]),
             emissionLambdaNm=None,
             excitationLambdaNm=None,
         )


### PR DESCRIPTION
closes #184.  `Metadata.channel.color` is now an (r,g,b,a) tuple.  If you want the original Elements integer format, use `color.as_abgr_u4()`