### PR TITLE
fix: Fix datetime extraction

### DIFF
--- a/src/nd2/_ome.py
+++ b/src/nd2/_ome.py
@@ -56,7 +56,7 @@ def nd2_ome_metadata(
     rdr = cast("ModernReader", f._rdr)
     meta = f.metadata
     images = []
-    acquisition_date = rdr._acquisition_date()
+    acquisition_date = rdr._acquisition_datetime()
     uuid_ = f"urn:uuid:{uuid.uuid4()}"
     sizes = dict(f.sizes)
     n_positions = sizes.pop(AXIS.POSITION, 1)

--- a/src/nd2/_util.py
+++ b/src/nd2/_util.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import re
+from contextlib import suppress
 from datetime import datetime, timezone
 from itertools import product
 from typing import TYPE_CHECKING, BinaryIO, NamedTuple, cast
@@ -81,7 +82,10 @@ def is_new_format(path: str) -> bool:
 
 def jdn_to_datetime(jdn: float, tz: timezone = timezone.utc) -> datetime:
     # astimezone() without arguments will use the system's local timezone
-    return datetime.fromtimestamp((jdn - 2440587.5) * 86400.0, tz).astimezone()
+    dt = datetime.fromtimestamp((jdn - 2440587.5) * 86400.0, tz)
+    with suppress(ValueError, OSError):
+        return dt.astimezone()
+    return dt
 
 
 # these are used has headers in the events() table

--- a/src/nd2/_util.py
+++ b/src/nd2/_util.py
@@ -80,7 +80,7 @@ def is_new_format(path: str) -> bool:
 
 
 def jdn_to_datetime(jdn: float, tz: timezone = timezone.utc) -> datetime:
-    return datetime.fromtimestamp((jdn - 2440587.5) * 86400.0, tz)
+    return datetime.fromtimestamp((jdn - 2440587.5) * 86400.0, tz).astimezone()
 
 
 def rgb_int_to_tuple(rgb: int) -> tuple[int, int, int]:

--- a/src/nd2/_util.py
+++ b/src/nd2/_util.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import math
+import os
 import re
 from contextlib import suppress
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from itertools import product
 from typing import TYPE_CHECKING, BinaryIO, NamedTuple, cast
 
@@ -82,7 +83,12 @@ def is_new_format(path: str) -> bool:
 
 def jdn_to_datetime(jdn: float, tz: timezone = timezone.utc) -> datetime:
     # astimezone() without arguments will use the system's local timezone
-    dt = datetime.fromtimestamp((jdn - 2440587.5) * 86400.0, tz)
+    t = (jdn - 2440587.5) * 86400.0
+    if os.name == "nt" and t < 0:
+        # Windows does not always support negative timestamps
+        dt = datetime.fromtimestamp(0, tz) + timedelta(seconds=t)
+    else:
+        dt = datetime.fromtimestamp(t, tz)
     with suppress(ValueError, OSError):
         return dt.astimezone()
     return dt

--- a/src/nd2/_util.py
+++ b/src/nd2/_util.py
@@ -84,10 +84,6 @@ def jdn_to_datetime(jdn: float, tz: timezone = timezone.utc) -> datetime:
     return datetime.fromtimestamp((jdn - 2440587.5) * 86400.0, tz).astimezone()
 
 
-def rgb_int_to_tuple(rgb: int) -> tuple[int, int, int]:
-    return ((rgb & 255), (rgb >> 8 & 255), (rgb >> 16 & 255))
-
-
 # these are used has headers in the events() table
 TIME_KEY = "Time [s]"
 Z_SERIES_KEY = "Z-Series"
@@ -132,15 +128,6 @@ TIME_FMT_STRINGS = [
     "%d-%b-%y %I:%M:%S %p",
     "%d/%m/%Y %I:%M:%S %p",
 ]
-
-
-def parse_time(time_str: str) -> datetime:
-    for fmt_str in TIME_FMT_STRINGS:
-        try:
-            return datetime.strptime(time_str, fmt_str)
-        except ValueError:
-            continue
-    raise ValueError(f"Could not parse {time_str}")  # pragma: no cover
 
 
 def convert_records_to_dict_of_lists(

--- a/src/nd2/_util.py
+++ b/src/nd2/_util.py
@@ -80,6 +80,7 @@ def is_new_format(path: str) -> bool:
 
 
 def jdn_to_datetime(jdn: float, tz: timezone = timezone.utc) -> datetime:
+    # astimezone() without arguments will use the system's local timezone
     return datetime.fromtimestamp((jdn - 2440587.5) * 86400.0, tz).astimezone()
 
 

--- a/src/nd2/_util.py
+++ b/src/nd2/_util.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import math
-import os
 import re
 from contextlib import suppress
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from itertools import product
 from typing import TYPE_CHECKING, BinaryIO, NamedTuple, cast
 
@@ -80,8 +79,10 @@ def is_new_format(path: str) -> bool:
     with open(path, "rb") as fh:
         return fh.read(4) == NEW_HEADER_MAGIC
 
+
 JDN_UNIX_EPOCH = 2440587.5
 SECONDS_PER_DAY = 86400
+
 
 def jdn_to_datetime(jdn: float, tz: timezone = timezone.utc) -> datetime:
     seconds_since_epoch = (jdn - JDN_UNIX_EPOCH) * SECONDS_PER_DAY

--- a/src/nd2/readers/_modern/modern_reader.py
+++ b/src/nd2/readers/_modern/modern_reader.py
@@ -528,20 +528,8 @@ class ModernReader(ND2Reader):
         k = b"CustomDataVar|AppInfo_V1_0!"
         return self._decode_chunk(k) if k in self.chunkmap else {}
 
-    def _acquisition_date(self) -> datetime.datetime | str | None:
-        """Try to extract acquisition date.
-
-        A best effort is made to extract a datetime object from the date string,
-        but if that fails, the raw string is returned.  Use isinstance() to
-        be safe.
-        """
-        date = self.text_info().get("date")
-        if date:
-            try:
-                return _util.parse_time(date)
-            except ValueError:
-                return date
-
+    def _acquisition_date(self) -> datetime.datetime | None:
+        """Try to extract acquisition date."""
         time = self._cached_global_metadata().get("time", {})
         jdn = time.get("absoluteJulianDayNumber")
         return _util.jdn_to_datetime(jdn) if jdn else None


### PR DESCRIPTION
This PR fixes datetime extraction by not using text_info, and instead, casting the jdn time in the global metadata to the local timezone.

closes #221
closes #225 