### PR TITLE
fix: use absolute path resolution for file handling in ND2Reader

### DIFF
--- a/src/nd2/_readers/protocol.py
+++ b/src/nd2/_readers/protocol.py
@@ -62,7 +62,7 @@ class ND2Reader(abc.ABC):
                 )
             ctx: AbstractContextManager[BinaryIO] = nullcontext(path)
         else:
-            path = Path(path).expanduser().resolve()
+            path = Path(path).expanduser().absolute()
             ctx = open(path, "rb")
 
         with ctx as fh:


### PR DESCRIPTION
closes #258 