### PR TITLE
feat: add support for user-defined custom metadata from ND acquisition

### DIFF
--- a/src/nd2/_nd2file.py
+++ b/src/nd2/_nd2file.py
@@ -702,28 +702,8 @@ class ND2File:
     # FIX: JM 2026-07-13 collected data from custom metadata in ND acquisition
     @cached_property
     def custom_metadata(self) -> dict[str, Any] | None:
-        """Return user-defined metadata saved with the NIS-Elements acquisition."""
-        if self.is_legacy:
-            return None
-
-        keys = [
-            key
-            for key in self._rdr.chunkmap
-            if b"CustomDescription" in key
-        ]
-
-        if not keys:
-            return None
-
-        # might be a smarter way to do this...
-        from ._parse._clx_lite import json_from_clx_lite_variant 
-        raw = self._rdr._load_chunk(keys[0])
-        return json_from_clx_lite_variant(
-            raw,
-            strip_prefix=False,
-            preserve_duplicates=True,
-            lists_to_indexed_dicts=False,
-        )
+        """Return user-defined NIS-Elements custom metadata, if present."""
+        return self._rdr.custom_metadata()
 
     def jobs(self) -> JobsDict | None:
         """Return JOBS metadata if the file was acquired using JOBS, else None.

--- a/src/nd2/_nd2file.py
+++ b/src/nd2/_nd2file.py
@@ -700,10 +700,10 @@ class ND2File:
         return self._rdr.custom_data()
 
     # FIX: JM 2026-07-13 collected data from custom metadata in ND acquisition
-    @cached_property
-    def custom_metadata(self) -> dict[str, Any] | None:
+    # @cached_property
+    def custom_metadata(self, strip_prefix=False) -> dict[str, Any] | None:
         """Return user-defined NIS-Elements custom metadata, if present."""
-        return self._rdr.custom_metadata()
+        return self._rdr.custom_metadata(strip_prefix=strip_prefix)
 
     def jobs(self) -> JobsDict | None:
         """Return JOBS metadata if the file was acquired using JOBS, else None.

--- a/src/nd2/_nd2file.py
+++ b/src/nd2/_nd2file.py
@@ -699,6 +699,32 @@ class ND2File:
         """Dict of various unstructured custom metadata."""
         return self._rdr.custom_data()
 
+    # FIX: JM 2026-07-13 collected data from custom metadata in ND acquisition
+    @cached_property
+    def custom_metadata(self) -> dict[str, Any] | None:
+        """Return user-defined metadata saved with the NIS-Elements acquisition."""
+        if self.is_legacy:
+            return None
+
+        keys = [
+            key
+            for key in self._rdr.chunkmap
+            if b"CustomDescription" in key
+        ]
+
+        if not keys:
+            return None
+
+        # might be a smarter way to do this...
+        from ._parse._clx_lite import json_from_clx_lite_variant 
+        raw = self._rdr._load_chunk(keys[0])
+        return json_from_clx_lite_variant(
+            raw,
+            strip_prefix=False,
+            preserve_duplicates=True,
+            lists_to_indexed_dicts=False,
+        )
+
     def jobs(self) -> JobsDict | None:
         """Return JOBS metadata if the file was acquired using JOBS, else None.
 

--- a/src/nd2/_parse/_clx_lite.py
+++ b/src/nd2/_parse/_clx_lite.py
@@ -157,6 +157,7 @@ def json_from_clx_lite_variant(
     _count: int = 1,
     *,
     lists_to_indexed_dicts: bool = True,
+    preserve_duplicates: bool = False, # FIX: JM 2026-07-13 allows for retrieving duplicates from custom metadata
 ) -> dict[str, JsonValueType]:
     output: dict[str, JsonValueType] = {}
     if not data:
@@ -231,7 +232,9 @@ def json_from_clx_lite_variant(
         else:
             # also never seen this
             value = None  # pragma: no cover
-        if name == "" and name in output:
+        # FIX: JM 2026-07-13, append whether or not name is empty
+        # if name == "" and name in output:
+        if name in output and (name == "" or preserve_duplicates):
             # nd2 uses empty strings as keys for lists
             if not isinstance(output[name], list):
                 output[name] = [output[name]]

--- a/src/nd2/_parse/_clx_lite.py
+++ b/src/nd2/_parse/_clx_lite.py
@@ -157,7 +157,7 @@ def json_from_clx_lite_variant(
     _count: int = 1,
     *,
     lists_to_indexed_dicts: bool = True,
-    preserve_duplicates: bool = False, # FIX: JM 2026-07-13 allows for retrieving duplicates from custom metadata
+    preserve_duplicates: bool = False, # FIX: JM 2026-07-13 
 ) -> dict[str, JsonValueType]:
     output: dict[str, JsonValueType] = {}
     if not data:
@@ -177,7 +177,7 @@ def json_from_clx_lite_variant(
                 deflated,
                 strip_prefix,
                 lists_to_indexed_dicts=lists_to_indexed_dicts,
-                preserve_duplicates=preserve_duplicates, # JM: 2026-07-13 fix to accomodate dupes
+                preserve_duplicates=preserve_duplicates, # JM: 2026-07-13 fix
             )
 
         if data_type == -1:
@@ -193,7 +193,7 @@ def json_from_clx_lite_variant(
                 strip_prefix,
                 item_count,
                 lists_to_indexed_dicts=lists_to_indexed_dicts,
-                preserve_duplicates=preserve_duplicates, # JM: 2026-07-13 fix to accomodate dupes
+                preserve_duplicates=preserve_duplicates, # JM: 2026-07-13 fix
             )
             stream.seek(item_count * 8, 1)
             # In the binary format, list items have empty ("") names.
@@ -225,7 +225,7 @@ def json_from_clx_lite_variant(
                         raw_bytes,
                         strip_prefix,
                         lists_to_indexed_dicts=lists_to_indexed_dicts,
-                        preserve_duplicates=preserve_duplicates, # JM: 2026-07-13 fix to accomodate dupes
+                        preserve_duplicates=preserve_duplicates, # JM: 2026-07-13 fix
                     )
             if not value:
                 value = list(raw_bytes)

--- a/src/nd2/_parse/_clx_lite.py
+++ b/src/nd2/_parse/_clx_lite.py
@@ -157,7 +157,7 @@ def json_from_clx_lite_variant(
     _count: int = 1,
     *,
     lists_to_indexed_dicts: bool = True,
-    preserve_duplicates: bool = False, # FIX: JM 2026-07-13 
+    preserve_duplicates: bool = False,  # FIX: JM 2026-07-13
 ) -> dict[str, JsonValueType]:
     output: dict[str, JsonValueType] = {}
     if not data:
@@ -177,7 +177,7 @@ def json_from_clx_lite_variant(
                 deflated,
                 strip_prefix,
                 lists_to_indexed_dicts=lists_to_indexed_dicts,
-                preserve_duplicates=preserve_duplicates, # JM: 2026-07-13 fix
+                preserve_duplicates=preserve_duplicates,  # JM: 2026-07-13 fix
             )
 
         if data_type == -1:
@@ -193,7 +193,7 @@ def json_from_clx_lite_variant(
                 strip_prefix,
                 item_count,
                 lists_to_indexed_dicts=lists_to_indexed_dicts,
-                preserve_duplicates=preserve_duplicates, # JM: 2026-07-13 fix
+                preserve_duplicates=preserve_duplicates,  # JM: 2026-07-13 fix
             )
             stream.seek(item_count * 8, 1)
             # In the binary format, list items have empty ("") names.
@@ -225,7 +225,7 @@ def json_from_clx_lite_variant(
                         raw_bytes,
                         strip_prefix,
                         lists_to_indexed_dicts=lists_to_indexed_dicts,
-                        preserve_duplicates=preserve_duplicates, # JM: 2026-07-13 fix
+                        preserve_duplicates=preserve_duplicates,  # JM: 2026-07-13 fix
                     )
             if not value:
                 value = list(raw_bytes)

--- a/src/nd2/_parse/_clx_lite.py
+++ b/src/nd2/_parse/_clx_lite.py
@@ -177,6 +177,7 @@ def json_from_clx_lite_variant(
                 deflated,
                 strip_prefix,
                 lists_to_indexed_dicts=lists_to_indexed_dicts,
+                preserve_duplicates=preserve_duplicates, # JM: 2026-07-13 fix to accomodate dupes
             )
 
         if data_type == -1:
@@ -192,6 +193,7 @@ def json_from_clx_lite_variant(
                 strip_prefix,
                 item_count,
                 lists_to_indexed_dicts=lists_to_indexed_dicts,
+                preserve_duplicates=preserve_duplicates, # JM: 2026-07-13 fix to accomodate dupes
             )
             stream.seek(item_count * 8, 1)
             # In the binary format, list items have empty ("") names.
@@ -223,6 +225,7 @@ def json_from_clx_lite_variant(
                         raw_bytes,
                         strip_prefix,
                         lists_to_indexed_dicts=lists_to_indexed_dicts,
+                        preserve_duplicates=preserve_duplicates, # JM: 2026-07-13 fix to accomodate dupes
                     )
             if not value:
                 value = list(raw_bytes)

--- a/src/nd2/_readers/_modern/modern_reader.py
+++ b/src/nd2/_readers/_modern/modern_reader.py
@@ -413,14 +413,12 @@ class ModernReader(ND2Reader):
             if k.startswith(b"CustomDataVar|")
         }
 
-
     def custom_metadata(self) -> dict[str, Any] | None:
         """Return user-defined NIS-Elements custom metadata, if present."""
         keys = [
             key
             for key in self.chunkmap
-            if key.startswith(b"CustomData|")
-            and b"CustomDescription" in key
+            if key.startswith(b"CustomData|") and b"CustomDescription" in key
         ]
 
         if not keys:
@@ -434,7 +432,6 @@ class ModernReader(ND2Reader):
             lists_to_indexed_dicts=False,
             preserve_duplicates=True,
         )
-
 
     def jobs(self) -> JobsDict | None:
         """Return JOBS metadata if the file was acquired using JOBS, else None.

--- a/src/nd2/_readers/_modern/modern_reader.py
+++ b/src/nd2/_readers/_modern/modern_reader.py
@@ -413,7 +413,7 @@ class ModernReader(ND2Reader):
             if k.startswith(b"CustomDataVar|")
         }
 
-    def custom_metadata(self) -> dict[str, Any] | None:
+    def custom_metadata(self, strip_prefix=False) -> dict[str, Any] | None:
         """Return user-defined NIS-Elements custom metadata, if present."""
         keys = [
             key
@@ -428,7 +428,7 @@ class ModernReader(ND2Reader):
 
         return json_from_clx_lite_variant(
             raw,
-            strip_prefix=False,
+            strip_prefix=strip_prefix,
             lists_to_indexed_dicts=False,
             preserve_duplicates=True,
         )

--- a/src/nd2/_readers/_modern/modern_reader.py
+++ b/src/nd2/_readers/_modern/modern_reader.py
@@ -272,7 +272,9 @@ class ModernReader(ND2Reader):
                 warnings.warn(f"Failed to load frame times: {e}", stacklevel=2)
                 self._frame_times = []
 
-        return cast("list[float]", self._frame_times)
+        # JM fix 2026-07-13
+        # return cast("list[float]", self._frame_times)
+        return self._frame_times
 
     def voxel_size(self) -> tuple[float, float, float]:
         meta = self.metadata()
@@ -410,6 +412,29 @@ class ModernReader(ND2Reader):
             for k in self.chunkmap
             if k.startswith(b"CustomDataVar|")
         }
+
+
+    def custom_metadata(self) -> dict[str, Any] | None:
+        """Return user-defined NIS-Elements custom metadata, if present."""
+        keys = [
+            key
+            for key in self.chunkmap
+            if key.startswith(b"CustomData|")
+            and b"CustomDescription" in key
+        ]
+
+        if not keys:
+            return None
+
+        raw = self._load_chunk(keys[0])
+
+        return json_from_clx_lite_variant(
+            raw,
+            strip_prefix=False,
+            lists_to_indexed_dicts=False,
+            preserve_duplicates=True,
+        )
+
 
     def jobs(self) -> JobsDict | None:
         """Return JOBS metadata if the file was acquired using JOBS, else None.

--- a/src/nd2/_readers/protocol.py
+++ b/src/nd2/_readers/protocol.py
@@ -189,7 +189,7 @@ class ND2Reader(abc.ABC):
         """Return all data from CustomData chunks in the file."""
         warnings.warn("CustomData is not relevant for legacy files", stacklevel=2)
         return {}
-    
+
     def custom_metadata(self) -> dict[str, Any] | None:
         """Return user-defined NIS-Elements custom metadata, if present."""
         return None

--- a/src/nd2/_readers/protocol.py
+++ b/src/nd2/_readers/protocol.py
@@ -189,6 +189,10 @@ class ND2Reader(abc.ABC):
         """Return all data from CustomData chunks in the file."""
         warnings.warn("CustomData is not relevant for legacy files", stacklevel=2)
         return {}
+    
+    def custom_metadata(self) -> dict[str, Any] | None:
+        """Return user-defined NIS-Elements custom metadata, if present."""
+        return None
 
     def jobs(self) -> JobsDict | None:
         """Return JOBS metadata if the file was acquired using JOBS, else None."""


### PR DESCRIPTION
We are using custom metadata when acquiring data via ND acquisition in Nikon Elements (AR 6.02.01 64-bit). We could not find the metadata in any of the commonly used metadata fields in ND2File. After poking around, we found the metadata lived in `CustomData|CustomDescriptionV1_0!`. Using `json_from_clx_lite_variant` without modification only loaded in a subset of the metadata. This turned out to be due to keys getting clobbered by https://github.com/tlambert03/nd2/blob/main/src/nd2/_parse/_clx_lite.py#L234 . This PR includes a minimal set of changes to safely load in custom metadata under the `custom_metadata` field. We also included an opt-in modification to the clx parser to prevent keys from getting clobbered.

Let us know if you need anything else here. 

