### PR TITLE
fix: create ND2 frame views with reshape

### DIFF
--- a/src/nd2/_nd2file.py
+++ b/src/nd2/_nd2file.py
@@ -1251,8 +1251,7 @@ class ND2File:
 
         !!! Tip "new in version 0.8.0"
         """
-        frame = self._rdr.read_frame(int(frame_index))
-        frame.shape = self._raw_frame_shape
+        frame = self._rdr.read_frame(int(frame_index)).reshape(self._raw_frame_shape)
         return frame.transpose((2, 0, 1, 3)).squeeze()
 
     @cached_property

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -14,10 +14,13 @@ from resource_backed_dask_array import ResourceBackedDaskArray
 DATA = Path(__file__).parent / "data"
 
 
+@pytest.mark.filterwarnings(
+    "error:Setting the shape on a NumPy array has been deprecated:DeprecationWarning"
+)
 def test_read_safety(new_nd2: Path):
     with ND2File(new_nd2) as nd:
         for i in range(nd._frame_count):
-            nd._rdr.read_frame(i)
+            nd.read_frame(i)
 
 
 def test_position(new_nd2: Path):


### PR DESCRIPTION
`ND2File.read_frame` changes the returned array shape through attribute assignment. Create each ND2 frame view with reshape. This keeps frame creation on the supported NumPy array API and avoids the NumPy 2.5 deprecation. Closes #301. All tests pass.
