### PR TITLE
feat: add exposure time and objective info into ome metadata

### DIFF
--- a/src/nd2/_ome.py
+++ b/src/nd2/_ome.py
@@ -69,12 +69,16 @@ def nd2_ome_metadata(
         (x for x in DimensionOrder if x.value.startswith(dims)), DimensionOrder.XYCZT
     )
 
+    # Exposure time and detectors come from raw metadata
+    raw_meta = rdr._cached_raw_metadata()
+    sample_settings = raw_meta.get("sPicturePlanes", {}).get("sSampleSetting", {})
+
     # if sizes.get(AXIS.CHANNEL, 1) > 1 and sizes.get(AXIS.RGB, 1) > 1:
     #     warn("multi-channel RGB images are not well supported in nd2 OME metadata.")
 
     instrument = m.Instrument(
         id="Instrument:0",
-        detectors=ome_detectors(rdr._cached_raw_metadata()),
+        detectors=ome_detectors(raw_meta),
         # TODO:
         # dichroics: List[Dichroic]
         # filter_sets: List[FilterSet]
@@ -84,6 +88,13 @@ def nd2_ome_metadata(
     )
 
     ch0 = next(iter(meta.channels or ()), None)
+    objective_settings = (
+        None
+        if ch0 is None
+        else m.ObjectiveSettings(
+            id="Objective:0", refractive_index=ch0.microscope.immersionRefractiveIndex
+        )
+    )
     channels = []
     for c_idx, ch in enumerate(meta.channels or ()):
         channel = m.Channel(
@@ -143,13 +154,24 @@ def nd2_ome_metadata(
                 # TODO: i think RGB might actually need to be 3 planes with 1 spp
                 z_idx = loop_idx.get(AXIS.Z, 0)
                 t_idx = loop_idx.get(AXIS.TIME, 0)
+
+                # sSampleSetting has one entry per acquisition (not per channel)
+                # Laser-scanning confocals use a single entry governing all channels
+                # Entry count is always either 1 or SizeC
+                ch_setting = sample_settings.get(f"a{c_idx}")
+                if ch_setting is None and len(sample_settings) == 1:
+                    ch_setting = next(iter(sample_settings.values()))
+
+                # 0.0 is a placeholder value so set that as None
+                exposure_time = (ch_setting or {}).get("dExposureTime") or None
+
                 planes.append(
                     m.Plane(
                         the_z=z_idx,
                         the_t=t_idx,
                         the_c=c_idx,
-                        # exposure_time=...,
-                        # exposure_time_unit=...,
+                        exposure_time=exposure_time,
+                        exposure_time_unit=UnitsTime.MILLISECOND,
                         delta_t=round(fm_ch.time.relativeTimeMs, 6),
                         delta_t_unit=UnitsTime.MILLISECOND,  # default is "s"
                         position_x=round(fm_ch.position.stagePositionUm.x, 6),
@@ -200,7 +222,7 @@ def nd2_ome_metadata(
         images.append(
             m.Image(
                 instrument_ref=m.InstrumentRef(id=instrument.id),
-                # objective_settings=...
+                objective_settings=objective_settings,
                 id=f"Image:{p}",
                 name=name,
                 pixels=pixels,
@@ -215,7 +237,7 @@ def nd2_ome_metadata(
                 id="Objective:0",
                 nominal_magnification=scope.objectiveMagnification,
                 lens_na=scope.objectiveNumericalAperture,
-                # model=... # something like "Plan Fluor 10x Ph1 DLL"
+                model=scope.objectiveName,
                 # immersion=scope.ome_objective_immersion(),
             )
         )

--- a/tests/test_ome.py
+++ b/tests/test_ome.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import nd2
 import pytest
+
+DATA = Path(__file__).parent / "data"
 
 
 def test_ome_meta(new_nd2: Path) -> None:
@@ -15,3 +19,32 @@ def test_ome_meta(new_nd2: Path) -> None:
     if new_nd2.name == "dims_p4z5t3c2y32x32.nd2":
         names = [img.name for img in meta.images]
         assert names == ["point name 1", "point name 2", "point name 3", "point name 4"]
+
+
+def test_ome_exposure_invariants(new_nd2: Path) -> None:
+    pytest.importorskip("ome_types")
+    with nd2.ND2File(new_nd2) as f:
+        meta = f.ome_metadata(include_unstructured=False)
+
+    for img in meta.images:
+        for plane in img.pixels.planes:
+            assert plane.exposure_time_unit.value == "ms"
+            assert plane.exposure_time is None or plane.exposure_time > 0
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("10ms_2xbin_100xmag.nd2", [10.0]),
+        ("Exp3_9.8.21_Mouse1_DiI_4x_2x2-Slide1-1_B12.nd2", [150.0, 100.0]),
+        ("cluster.nd2", [996.9975547008216] * 2),
+        ("ML_06_72_ni_all8-MaxIP.nd2", [None] * 5),
+    ],
+)
+def test_ome_exposure_vals(name: str, expected: list[float | None]) -> None:
+    pytest.importorskip("ome_types")
+    with nd2.ND2File(DATA / name) as f:
+        meta = f.ome_metadata(include_unstructured=False)
+
+    by_channel = {p.the_c: p.exposure_time for p in meta.images[0].pixels.planes}
+    assert [by_channel[channel] for channel in range(len(expected))] == expected


### PR DESCRIPTION
Adds three fields that `_ome.py` already pulls values for:

- `Plane.exposure_time`: `dExposureTime` from the raw metadata.
- `Objective.model`: from `Microscope.objectiveName`.
- `ObjectiveSettings.refractive_index`: from `Microscope.immersionRefractiveIndex`.

## Notes
- OME exposure time defaults to seconds so `Plane.exposure_time_unit` is set as milliseconds explicitly.
- If several channels have one `sSampleSetting` entry, it gets propagated to every channel. This is to accommodate laser-scanning confocals which write one setting to all detectors. Cameras write one entry per channel so it's either `SizeC` or 1 on the sample files. Happy to make it strictly positional instead if that's preferred.
- `dExposureTime == 0.0` is treated as absent and written as `None`.
- `ObjectiveSettings` as a whole is now written on every `Image` whenever an `Objective` exists, even if the refractive index is not present.

I left out `Objective.immersion` (see #294, `1.0` for refractive index is ambiguous) and `Channel.detector_settings` because `ome_detectors` collapses `(model, serial)` into a set so which channel a camera came from is lost. 

Added tests in `tests/test_ome.py`

Two failures (may also fail in CI) are pre-existing and unrelated to these changes: `_nd2file.py:1255` assigns `frame.shape` which is deprecated in numpy 2.5 and `filterwarnings = ["error", ...]` escalates it to an error. The failing test leaves the nd2 file open so this cascades into ~300 failures in the rest of the test suite. Also pre-existing: mypy is complaining about a redundant cast in `_readers/_modern/modern_reader.py:275`.